### PR TITLE
Fix/delete e tipo norma 

### DIFF
--- a/src/entities/Norma.ts
+++ b/src/entities/Norma.ts
@@ -17,9 +17,9 @@ interface Norma {
 }
 
 interface NormaListObj {
-    id?: number;
+    id_norma: number;
     titulo?: string;
-    id_tipo?: number;
+    id_tipo: number;
     outro_tipo?: string;
     data_norma?: string;
     assuntos?: string[];

--- a/src/tables/NormasTable/helper.tsx
+++ b/src/tables/NormasTable/helper.tsx
@@ -14,7 +14,7 @@ class NormasTableHelper {
         return data.map((normaObj) => ({
             id_norma: normaObj.id_norma,
             data: normaObj.data_norma,
-            tipo: TiposNormasLabel.get(normaObj.tipo_norma) || "-",
+            tipo: TiposNormasLabel.get(normaObj.id_tipo) || "-",
             titulo: normaObj.titulo,
             acoes: this.acoesComponent(normaObj, addOptions),
         }));


### PR DESCRIPTION
Boa noite,

Com o merge ontem da branchDoMateus e das correões que fiz o código quebrou:

`NormasTable/context.tsx(122,51):
Property 'id_norma' does not exist on type 'NormaListObj'.  TS2339

    120 |             const normasService = new NormasService();
    121 |             const codigo_cidade = user?.codigo_cidade || 0;
  > 122 |             await normasService.deleteNorma(norma.id_norma, codigo_cidade);
        |                                                   ^
    123 |             clearModal();
    124 |         } catch (err) {
    125 |  


Property 'tipo_norma' does not exist on type 'NormaListObj'. Did you mean 'id_norma'?  TS2551

    15 |             id_norma: normaObj.id_norma,
    16 |             data: normaObj.data_norma,
  > 17 |             tipo: TiposNormasLabel.get(normaObj.tipo_norma) || "-",
       |                                                 ^
    18 |             titulo: normaObj.titulo,
    19 |             acoes: this.acoesComponent(normaObj, addOptions),
    20 |         }));`


Corrigi aqui e rodou, só não sei se esta bom dessa forma.